### PR TITLE
fix search path concatenation

### DIFF
--- a/flycheck-hdevtools.el
+++ b/flycheck-hdevtools.el
@@ -44,13 +44,13 @@ See URL `https://github.com/bitc/hdevtools'."
   ("hdevtools" "check" "-g" "-Wall"
    (eval (when flycheck-ghc-no-user-package-database
            (list "-g" "-no-user-package-db")))
-   (eval (apply #'append (mapcar (lambda (db) (list "-g" "-package-db" "-g" db))
+   (eval (apply #'append (mapcar (lambda (db) (concat "-g-package-db" db))
                                  flycheck-ghc-package-databases)))
-   (eval (list
-          "-g" "-i" "-g"
+   (eval (concat
+          "-g-i"
           (flycheck-module-root-directory
            (flycheck-find-in-buffer flycheck-haskell-module-re))))
-   (eval (apply #'append (mapcar (lambda (db) (list "-g" "-i" "-g" db))
+   (eval (apply #'append (mapcar (lambda (db) (list (concat "-g-i" db)))
                                  flycheck-ghc-search-path)))
    source)
   :error-patterns


### PR DESCRIPTION
Any entries in flycheck-ghc-package-databases or flycheck-ghc-search-path are not being recognized by hdevtools because of the extra spaces; simple concatentation fixes this and makes it possible to use hdevtools in a cabal sandbox if flycheck-haskell is setting these variables.