### PR TITLE
Use `source-inplace` instead of `source`

### DIFF
--- a/flycheck-hdevtools.el
+++ b/flycheck-hdevtools.el
@@ -52,7 +52,7 @@ See URL `https://github.com/bitc/hdevtools'."
            (flycheck-find-in-buffer flycheck-haskell-module-re))))
    (eval (apply #'append (mapcar (lambda (db) (list (concat "-g-i" db)))
                                  flycheck-ghc-search-path)))
-   source)
+   source-inplace)
   :error-patterns
   ((warning line-start (file-name) ":" line ":" column ":"
             (or " " "\n ") "Warning:" (optional "\n")


### PR DESCRIPTION
hdevtools uses the directory that the source file is found in to locate cabal sandboxes and (in version 1.2.1) to locate `stack.yaml` files.

Using `source` makes hdevtools unable to find those, since it then only has a temporary directory as the location of the file.

On the other hand, using a filename that doesn't correspond exactly to the name of the module is fine with hdevtools, and doesn't generate any spurious warnings. Therefore, `source-inplace` is the better choice.